### PR TITLE
fix mapping to base of polyserve

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ module.exports = {
         "**/*.js"
       ],
       exclude: [
-        "/polymer/polymer.js",
-        "/platform/platform.js"
+        "/polymer/polymer.html",
+        "/platform/platform.html"
       ]
     }
   }
@@ -86,11 +86,11 @@ module.exports = {
       dir: "./coverage",
       reporters: ["text-summary", "lcov"],
       include: [
-        "**/*.js"
+        "**/*.html"
       ],
       exclude: [
-        "/polymer/polymer.js",
-        "/platform/platform.js"
+        "/polymer/polymer.html",
+        "/platform/platform.html"
       ],
       thresholds: {
         global: {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -48,32 +48,76 @@ function instrumentAsset(assetPath, req){
 }
 
 /**
+ * Taken from: https://github.com/Polymer/web-component-tester/blob/master/runner/config.ts
+ * config helper: A basic function to synchronously read JSON,
+ * log any errors, and return null if no file or invalid JSON
+ * was found.
+ */
+function readJsonSync(filename, dir) {
+  const configPath = path.resolve(dir || '', filename);
+  let config;
+  try {
+    config = fs.readFileSync(configPath, 'utf-8');
+  } catch (e) {
+    return null;
+  }
+  try {
+    return JSON.parse(config);
+  } catch (e) {
+    console.error(`Could not parse ${configPath} as JSON`);
+    console.error(e);
+  }
+  return null;
+}
+
+/**
+ * Taken from: https://github.com/Polymer/web-component-tester/blob/master/runner/config.ts
+ * Determines the package name by reading from the following sources:
+ *
+ * 1. `options.packageName`
+ * 2. bower.json or package.json, depending on options.npm
+ */
+function getPackageName(options) {
+  if (options.packageName) {
+    return options.packageName;
+  }
+  const manifestName = (options.npm ? 'package.json' : 'bower.json');
+  const manifest = readJsonSync(manifestName, options.root);
+  if (manifest !== null) {
+    return manifest.name;
+  }
+  const basename = path.basename(options.root);
+  console.warn(
+      `no ${manifestName} found, defaulting to packageName=${basename}`);
+  return basename;
+}
+
+/**
  * Middleware that serves an instrumented asset based on user
  * configuration of coverage
  */
 function coverageMiddleware(root, options, emitter) {
-  var mappings = emitter.options.webserver.pathMappings;
+  const basename = getPackageName(options);
+  const basepath = emitter.options.clientOptions.root + basename + '/';
 
   return function(req, res, next) {
     var absolutePath = req.url.replace(/^\/[^/]+\/[^/]+/, root);
-    var relativePath = req.url.replace(/^\/[^/]+\/[^/]+/, '');
 
     // always ignore platform files in addition to user's blacklist
     var blacklist = ['/web-component-tester/*'];
     if(options.exclude) {
       blacklist = blacklist.concat(options.exclude);
     }
-    var whitelist = options.include;
+    var whitelist = options.include.map(x => basepath + x);
 
     // cache the webserver root for user supplied instrumenter
     this.root = root;
-
     // check asset against rules
-    var process = match(relativePath, whitelist) && !match(relativePath, blacklist);
+    var process = match(req.url, whitelist) && !match(req.url, blacklist);
 
     // instrument unfiltered assets
     if ( process ) {
-      emitter.emit('log:debug', 'coverage', 'instrument', relativePath);
+      emitter.emit('log:debug', 'coverage', 'instrument', req.url);
 
       if (absolutePath.match(/\.htm(l)?$/)) {
         var html = instrumentHtml(absolutePath, req);
@@ -82,7 +126,7 @@ function coverageMiddleware(root, options, emitter) {
 
       return res.send( instrumentAsset(absolutePath, req) );
     } else {
-      emitter.emit('log:debug', 'coverage', 'skip      ', relativePath);
+      emitter.emit('log:debug', 'coverage', 'skip      ', req.url);
       return next();
     }
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wct-istanbub",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Instanbul coverage reporting for projects being tested by web-component-tester",
   "main": "lib/plugin.js",
   "scripts": {


### PR DESCRIPTION
This PR adds the basepath used by polyserve -> /components/{packagename}/ to the whitelist variables, this means that all the files of your own project can be tracked by the tests.

This is related to #1  and tested in https://travis-ci.org/Bubbit/polymerTesting/builds/318472925

I'm still thinking about a cleaner solution by creating a better matching solution, but for now this can work for most use cases.