### PR TITLE
Load source maps

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -73,7 +73,7 @@ function instrumentFile(path, req, html) {
     if (!cache[asset]) {
       code = fs.readFileSync(path, 'utf8');
       cache[asset] = html ? scriptHook(code, { scriptCallback: instrumentScript }) :
-        instrumenter.instrumentSync(code, path);
+        instrumenter.instrumentSync(code, path, getSourceMap(code, path));
     }
 
     function instrumentScript(code) {
@@ -83,6 +83,28 @@ function instrumentFile(path, req, html) {
     return '';
   }
   return cache[asset];
+}
+
+/**
+ * Try to get source map for given code
+ * @param {string} code Code to get source map for
+ * @param {string} path Path to code
+ */
+function getSourceMap(code, path) {
+  let map = undefined;
+  const mapMatch = /\/\/# sourceMappingURL=([^\s]+.js.map)$/.exec(code);
+  if (mapMatch != null && path != null) {
+    const mapPath = path.split('/').slice(0, -1).join('/') + '/' + mapMatch[1];
+    
+    if (fs.existsSync(mapPath)) {
+      try {
+        const rawMap = fs.readFileSync(mapPath, 'utf8');
+        map = JSON.parse(rawMap);
+      } catch (_) {}
+    }
+  }
+
+  return map;
 }
 
 /**

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,4 +1,5 @@
 const { createReporter, config } = require('istanbul-api');
+const libSourceMaps = require('istanbul-lib-source-maps');
 const istanbulCoverage = require('istanbul-lib-coverage');
 const express = require('express');
 const middleware = require('./middleware');
@@ -31,11 +32,15 @@ function Listener(emitter, pluginOptions) {
       throw Error('Tests failed. Not writing coverage report.');
     }
 
+    const mapStore = libSourceMaps.createSourceMapStore({});
+    const transformed = mapStore.transformCoverage(this.map);
+
     // Log a new line to not overwrite the test results outputted by WCT
     console.log('\n');
-    this.reporter.write(this.map);
+    this.reporter.write(transformed.map);
 
-    if (!validator.validate(this.map)) {
+    mapStore.dispose();
+    if (!validator.validate(transformed.map)) {
       throw Error('Coverage failed');
     }
   }.bind(this));

--- a/test/mocks/mockMapped.js
+++ b/test/mocks/mockMapped.js
@@ -1,0 +1,5 @@
+(function () {
+    var foo = 5;
+    console.log(foo);
+})();
+//# sourceMappingURL=mockMapped.js.map

--- a/test/mocks/mockMapped.js.map
+++ b/test/mocks/mockMapped.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"mockMapped.js","sourceRoot":"","sources":["mockMapped.ts"],"names":[],"mappings":"AAAA,CAAC;IACG,IAAM,GAAG,GAAG,CAAC,CAAA;IACb,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC;AACrB,CAAC,CAAC,EAAE,CAAC"}

--- a/test/mocks/mockMapped.ts
+++ b/test/mocks/mockMapped.ts
@@ -1,0 +1,4 @@
+(() => {
+    const foo = 5
+    console.log(foo);
+})();


### PR DESCRIPTION
I am currently using wct-istanbub to measure code coverage on Polymer components written using TypeScript. This works well with the drawback that it is measured on the JavaScript files instead of the TypeScript sources.

This change checks for a sourceMappingUrl comment on the file and loads it if possible so that the result can be mapped to the source files.