### PR TITLE
fix: Fix namespace (WCT.share)  when is replaced in the middleware

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,7 +1,6 @@
 const minimatch = require('minimatch');
 const fs = require('fs');
 const path = require('path');
-const parseurl = require('parseurl');
 const scriptHook = require('html-script-hook');
 const polymerBuild = require('polymer-build');
 const browserCapabilities = require('browser-capabilities');
@@ -42,7 +41,7 @@ function createInstrumenter(plugins) {
 }
 
 function replaceCoverage(code) {
-  return code.replace('coverage = global[gcv] || (global[gcv] = {});', 'coverage = global.WCT.share.__coverage__ || (global.WCT = { share: { __coverage__: {} } }).share.__coverage__;');
+  return code.replace('coverage = global[gcv] || (global[gcv] = {});', 'coverage = global.WCT.share.__coverage__ || (global.WCT.share.__coverage__ = {});');
 }
 
 function transform(req, body, packageName, filePath, npm, root, componentUrl, moduleResolution, isComponentRequestOverride) {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "istanbul-lib-source-maps": "^2.0.1",
     "merge-source-map": "^1.1.0",
     "minimatch": "^3.0.0",
-    "parseurl": "^1.3.0",
     "polymer-build": "^3.0.1",
     "polyserve": "^0.27.11",
     "web-component-tester": "^6.6.0",


### PR DESCRIPTION
The middleware replace namespace (WCT.share) by a new object and the message with coverage result is emitted with empty value.

When namespace is replaced, maybe, is lost de proxy or similar mechanism.

*Extra*: remove unnecesary dependency `parseurl`

Fix #32 